### PR TITLE
refactor(rewrite-script): infer async methods from known types

### DIFF
--- a/lib/executor.js
+++ b/lib/executor.js
@@ -3,11 +3,12 @@ const Script = require('vm').Script;
 const falafel = require('falafel');
 const debug = require('util').debuglog('translator');
 
-// @TODO: We are just checking the existence of these method names, however the
-//        more complete solution would be to introspect if they are indeed the type
-//        of object we expect them to be.
-const ASYNC_METHODS = [
-  // Database
+const Db = require('./db');
+
+const DB_METHODS = Object.getOwnPropertyNames(Db.prototype);
+const DB_COMPAT_METHODS = [ 'getCollection' ];
+
+const DB_ASYNC_METHODS = [
   'auth', 'adminCommand', 'cloneCollection', 'cloneDatabase', 'commandHelp',
   'copyDatabase', 'createCollection', 'createRole', 'createUser', 'createView',
   'currentOp', 'dropAllRoles', 'dropAllUsers', 'dropDatabase', 'dropRole', 'dropUser',
@@ -19,9 +20,10 @@ const ASYNC_METHODS = [
   'removeUser', 'repairDatabase', 'resetError', 'revokePrivilegesFromRole',
   'revokeRolesFromRole', 'revokeRolesFromUser', 'runCommand', 'serverBuildInfo',
   'serverCmdLineOpts', 'serverStatus', 'shutdownServer', 'stats', 'updateRole',
-  'updateUser', 'version',
+  'updateUser', 'version'
+];
 
-  // Collections
+const COLLECTION_ASYNC_METHODS = [
   'bulkWrite', 'count', 'createIndex', 'createIndexes', 'deleteMany', 'deleteOne',
   'distinct', 'drop', 'dropAllIndexes', 'dropIndex', 'dropIndexes', 'ensureIndex',
   'findAndModify', 'findAndRemove', 'findOne', 'findOneAndDelete', 'findOneAndReplace',
@@ -30,17 +32,16 @@ const ASYNC_METHODS = [
   'options', 'parallelCollectionScan', 'reIndex', 'remove', 'rename', 'replaceOne',
   'save', 'stats', 'update', 'updateMany', 'updateOne',
 
-  // Collection (legacy)
-  'getIndexes', 'getIndexKeys', 'itcount', 'runCommand', 'validate',
+  // compat
+  'getIndexes', 'getIndexKeys', 'itcount', 'runCommand', 'validate'
+];
 
-  // Cursors
-  'close', 'count', 'hasNext', 'next', 'nextObject', 'toArray',
+const CREATE_CURSOR_METHODS = [ 'find', 'listIndexes', 'aggregate' ];
+const CURSOR_ASYNC_METHODS = [
+  'close', 'count', 'explain', 'hasNext', 'next', 'nextObject', 'toArray',
 
-  // Cursors (legacy)
-  'arrayAccess', 'countReturn', 'length', 'size',
-
-  // Databases
-  'dropDatabase', 'createView'
+  // compat
+  'arrayAccess', 'countReturn', 'length', 'size'
 ];
 
 function isIIFE(node) {
@@ -165,6 +166,7 @@ function applyAsyncWrapper(node, programNode) {
     return;
   }
 
+  debug('  -> applying async wrapper');
   programNode = programNode || node;
   let needsExpressionSemicolon = !(node.source().endsWith(';'));
   let needsEndSemicolon = (node === programNode) ? true : !(programNode.source().endsWith(';'));
@@ -178,6 +180,95 @@ function applyAsyncWrapper(node, programNode) {
   node.asyncWrapped = true;
 }
 
+const TYPE_UNKNOWN = 0;
+const TYPE_DB = 1;
+const TYPE_COLLECTION = 2;
+const TYPE_CURSOR = 3;
+
+function typeToString(type) {
+  if (type === TYPE_DB) return 'db';
+  else if (type === TYPE_COLLECTION) return 'collection';
+  else if (type === TYPE_CURSOR) return 'cursor';
+  return 'unknown';
+}
+
+function getCallParts(node, parts) {
+  parts = parts || [];
+  if (node.type === 'MemberExpression') {
+    parts.unshift(node.property.name);
+    parts.unshift(node.object.name);
+  } else if (node.type === 'Identifier') {
+    parts.unshift(node.name);
+  } else {
+    if (node.callee && node.callee.type === 'MemberExpression') {
+      parts.unshift(node.callee.property.name);
+
+      if (node.callee.object.type === 'CallExpression') {
+        getCallParts(node.callee.object, parts);
+      } else if (node.callee.object.type === 'MemberExpression') {
+        parts.unshift(node.callee.object.property.name);
+        parts.unshift(node.callee.object.object.name);
+      } else if (node.callee.object.type === 'Identifier') {
+        parts.unshift(node.callee.object.name);
+      }
+    }
+  }
+
+  return parts;
+}
+
+const hasProp = {}.hasOwnProperty;
+function inferCalleeType(node, typeCache) {
+  let type = TYPE_UNKNOWN;
+  let parts = getCallParts(node);
+  if (parts.length === 0) {
+    return type;
+  }
+
+  if (parts[0] === 'db') {
+    if (parts.length > 1 && (DB_METHODS.indexOf(parts[1]) === -1 || DB_COMPAT_METHODS.indexOf(parts[1]) !== -1)) {
+      if (CREATE_CURSOR_METHODS.indexOf(parts[2]) !== -1) {
+        type = TYPE_CURSOR;
+      } else {
+        type = TYPE_COLLECTION;
+      }
+    } else {
+      type = TYPE_DB;
+    }
+  } else if (typeCache && hasProp.call(typeCache, parts[0])) {
+    type = typeCache[parts[0]];
+  }
+
+  return type;
+}
+
+function maybeCacheAssignedType(lhs, rhs, typeCache) {
+  if (rhs.type === 'ArrayExpression') {
+    return;
+  }
+
+  let type = inferCalleeType(rhs, typeCache);
+  if (type !== TYPE_UNKNOWN) {
+    debug('  -> cached `' + lhs + '` as type:', typeToString(type));
+    typeCache[lhs] = type;
+  }
+}
+
+function isAsyncCallExpression(node, typeCache) {
+  let method = node.callee.property.name;
+  let type = inferCalleeType(node, typeCache);
+
+  if (type === TYPE_COLLECTION) {
+    return COLLECTION_ASYNC_METHODS.indexOf(method) !== -1;
+  } else if (type === TYPE_CURSOR) {
+    return CURSOR_ASYNC_METHODS.indexOf(method) !== -1;
+  } else if (type === TYPE_DB) {
+    return DB_ASYNC_METHODS.indexOf(method) !== -1;
+  }
+
+  return false;
+}
+
 /**
  *
  * @param {*} src
@@ -188,12 +279,19 @@ function rewriteScript(src, options) {
   options = options || { repl: false };
 
   let rewriteCache = [];
+  let typeCache = options.typeCache || Object.create(null);
   let output = falafel(src, function(node) {
     if (node.type === 'VariableDeclaration') {
       debug('[VARDEC]: ', node.source());
-      if (options.repl) {
-        if (node.declarations.some(d => d.init.awaited)) {
+
+      if (node.declarations.some(d => d.init && d.init.awaited)) {
+        if (options.repl) {
           applyAsyncWrapper(node.declarations[0].init);  // TODO: what about multiple declarations?
+        }
+      } else {
+        let decl = node.declarations[0];
+        if (decl.init) {
+          maybeCacheAssignedType(decl.id.name, decl.init, typeCache);
         }
       }
     }
@@ -202,6 +300,8 @@ function rewriteScript(src, options) {
       debug('[ASSGNEXPR]: ', node.source());
       if (node.right.awaited) {
         rewriteCache.push(node.left.name);
+      } else {
+        maybeCacheAssignedType(node.left.name, node.right, typeCache);
       }
     }
 
@@ -213,8 +313,6 @@ function rewriteScript(src, options) {
         debug('[CALLEXPR]: ', node.source());
       }
 
-      // NOTE: special case for `assert.throws` with an async argument
-      // if (isAssertThrows(node.callee)) console.dir(node, { depth: null });
       if ((isAssertThrows(node.callee) || isAsyncThrowsMethod(node.callee)) &&
           node.arguments.some(a => a.awaited)) {
         node.callee.prepend('await ');
@@ -232,7 +330,8 @@ function rewriteScript(src, options) {
       if (!node.callee || !node.callee.property) return;
 
       let source = node.source();
-      if (ASYNC_METHODS.indexOf(node.callee.property.name) !== -1 && !isIIFE(node)) {
+
+      if (isAsyncCallExpression(node, typeCache) && !isIIFE(node)) {
         // NOTE: this will have to become _much_ smarter, but solves current test cases, specifically
         //       this addresses cases such as `assert.eq(await cursor.next()` not requiring a await
         //       before the `assert.eq`.
@@ -270,6 +369,7 @@ function rewriteScript(src, options) {
               applyAsyncWrapper(node);
             } else {
               applyAsyncWrapper(programNode, programNode);
+              node.parent.asyncWrapped = true;
             }
           }
         }
@@ -343,3 +443,8 @@ class Executor {
 
 module.exports = Executor;
 module.exports.rewriteScript = rewriteScript;
+module.exports.inferCalleeType = inferCalleeType;
+module.exports.TYPE_UNKNOWN = TYPE_UNKNOWN;
+module.exports.TYPE_DB = TYPE_DB;
+module.exports.TYPE_COLLECTION = TYPE_COLLECTION;
+module.exports.TYPE_CURSOR = TYPE_CURSOR;

--- a/test/repl/repl_rewrite_tests.js
+++ b/test/repl/repl_rewrite_tests.js
@@ -1,6 +1,15 @@
 'use strict';
-const assert = require('assert'),
-      rewriteScript = require('../../lib/executor').rewriteScript;
+const falafel = require('falafel');
+const assert = require('assert');
+const {
+  rewriteScript,
+  inferCalleeType,
+  TYPE_UNKNOWN,
+  TYPE_DB,
+  TYPE_COLLECTION,
+  TYPE_CURSOR
+} = require('../../lib/executor');
+
 
 function describeEx(desc, fn, tests) {
   describe(desc, function() {
@@ -21,8 +30,8 @@ describe('Repl Rewrite Tests', function() {
   describeEx('async wrapping (for REPL)', rewriteScriptREPL, [
     {
       name: 'should wrap assignment with async operations with a wrapper for immediate execution',
-      input: 'x = t.find(querySpec).count();',
-      expected: 'x = (() => { async function _wrap() { return await t.find(querySpec).count(); } return _wrap(); })();'
+      input: 'x = db.test.find(querySpec).count();',
+      expected: 'x = (() => { async function _wrap() { return await db.test.find(querySpec).count(); } return _wrap(); })();'
     },
     {
       name: 'should wrap VariableAssignment expressions with async wrapper if they are assigned to async method results',
@@ -31,13 +40,13 @@ describe('Repl Rewrite Tests', function() {
     },
     {
       name: 'should wrap async method args with a wrapper for imemdiate execution (1)',
-      input: 'assert.writeOK(t.mycoll.insert({}));',
-      expected: '(() => { async function _wrap() { return assert.writeOK(await t.mycoll.insert({})); } return _wrap(); })();'
+      input: 'assert.writeOK(db.mycoll.insert({}));',
+      expected: '(() => { async function _wrap() { return assert.writeOK(await db.mycoll.insert({})); } return _wrap(); })();'
     },
     {
       name: 'should wrap async method args with a wrapper for imemdiate execution (2)',
-      input: 'assert.writeOK(10, t.mycoll.insert({}));',
-      expected: '(() => { async function _wrap() { return assert.writeOK(10, await t.mycoll.insert({})); } return _wrap(); })();'
+      input: 'assert.writeOK(10, db.mycoll.insert({}));',
+      expected: '(() => { async function _wrap() { return assert.writeOK(10, await db.mycoll.insert({})); } return _wrap(); })();'
     },
     {
       name: 'should not wrap for-loop if loop contains async operation',
@@ -69,26 +78,26 @@ describe('Repl Rewrite Tests', function() {
   describeEx('async arguments', rewriteScript, [
     {
       name: 'should not prepend await to a sync method containing an async argument',
-      input: "assert.eq(cursor.next(), {_id: 1, strs: ['2000', '60']});",
-      expected: "assert.eq(await cursor.next(), {_id: 1, strs: ['2000', '60']});"
+      input: "assert.eq(db.test.find({}).next(), {_id: 1, strs: ['2000', '60']});",
+      expected: "assert.eq(await db.test.find({}).next(), {_id: 1, strs: ['2000', '60']});"
     },
     {
       name: 'should not prepend await to a sync method containing multiple async arguments',
-      input: 'assert.eq(cursor.next(), cursor.next());',
-      expected: 'assert.eq(await cursor.next(), await cursor.next());'
+      input: 'assert.eq(db.test.find({}).next(), db.test.find({}).next());',
+      expected: 'assert.eq(await db.test.find({}).next(), await db.test.find({}).next());'
     }
   ]);
 
   describeEx('assertions', rewriteScript, [
     {
       name: 'should rewrite async methods in `assert.throws` to use async form',
-      input: 'assert.throws(function() { t.find({$and: 4}).toArray(); });',
-      expected: 'await assert.throws(async function() { await t.find({$and: 4}).toArray(); });'
+      input: 'assert.throws(function() { db.test.find({$and: 4}).toArray(); });',
+      expected: 'await assert.throws(async function() { await db.test.find({$and: 4}).toArray(); });'
     },
     {
       name: 'should rewrite async methods in `assert.throws` to use async form within a function',
-      input: 'function check() { assert.throws(function() { t.find({$and: 4}).toArray(); }); }',
-      expected: 'async function check() { await assert.throws(async function() { await t.find({$and: 4}).toArray(); }); }'
+      input: 'function check() { assert.throws(function() { db.test.find({$and: 4}).toArray(); }); }',
+      expected: 'async function check() { await assert.throws(async function() { await db.test.find({$and: 4}).toArray(); }); }'
     },
     {
       name: 'should rewrite async methods in `assert.commandFailed` to use async form',
@@ -97,8 +106,8 @@ describe('Repl Rewrite Tests', function() {
     },
     {
       name: 'should not rewrite async op inside async assertion method',
-      input: 'assert.commandWorked(t.createIndex({x: 1}, {unique: true}));',
-      expected: 'await assert.commandWorked(t.createIndex({x: 1}, {unique: true}));'
+      input: 'assert.commandWorked(db.test.createIndex({x: 1}, {unique: true}));',
+      expected: 'await assert.commandWorked(db.test.createIndex({x: 1}, {unique: true}));'
     },
     {
       name: 'should not rewrite async op inside async assertion method (within assignment)',
@@ -107,11 +116,53 @@ describe('Repl Rewrite Tests', function() {
     }
   ]);
 
+  describe('async call expression detection', function() {
+    it('inferCalleeType', function() {
+      // returns the last logical call expression
+      function lastCallExpression(src) {
+        let node;
+        falafel(src, n => { if (n.type === 'CallExpression') node = n; });
+        return node;
+      }
+
+      assert.equal(TYPE_CURSOR,
+        inferCalleeType(lastCallExpression('db.basic_test_1.find({}).skip(5).limit(10).explain();')));
+      assert.equal(TYPE_CURSOR, inferCalleeType(lastCallExpression('db.getCollection("test_db").find()')));
+      assert.equal(TYPE_COLLECTION, inferCalleeType(lastCallExpression('db.getCollection("test")')));
+      assert.equal(TYPE_COLLECTION, inferCalleeType(lastCallExpression('db.basic_test_1.explain();')));
+      assert.equal(TYPE_DB, inferCalleeType(lastCallExpression('db.adminCommand()')));
+      assert.equal(TYPE_UNKNOWN, inferCalleeType(lastCallExpression('testing.adminCommand()')));
+      assert.equal(TYPE_DB, inferCalleeType(lastCallExpression('testing.adminCommand()'), { 'testing': TYPE_DB }));
+    });
+
+    it('assignment', function() {
+      let typeCache = Object.create(null);
+      rewriteScript('x = db.my_coll', { typeCache: typeCache });
+      assert.equal(typeCache.x, TYPE_COLLECTION);
+
+      typeCache = Object.create(null);
+      rewriteScript('var y = db.adminCommand()', { typeCache: typeCache });
+      assert(typeof typeCache.y === 'undefined');
+
+      typeCache = Object.create(null);
+      rewriteScript('z = db.my_coll.find({})', { typeCache: typeCache });
+      assert.equal(typeCache.z, TYPE_CURSOR);
+
+      typeCache = Object.create(null);
+      rewriteScript('a = db', { typeCache: typeCache });
+      assert.equal(typeCache.a, TYPE_DB);
+    });
+
+    it('should not infer type with basic expression', function() {
+      assert.doesNotThrow(() => rewriteScript('arr = [2, 4, 4, 4, 5, 5, 7, 9];'));
+    });
+  });
+
   describeEx('basic', rewriteScript, [
     {
       name: 'should rewrite an async method to a generator with await',
-      input: 'function test() { t.find(querySpec).sort(sortSpec).batchSize(1000).count(); }',
-      expected: 'async function test() { await t.find(querySpec).sort(sortSpec).batchSize(1000).count(); }'
+      input: 'function test() { db.test.find(querySpec).sort(sortSpec).batchSize(1000).count(); }',
+      expected: 'async function test() { await db.test.find(querySpec).sort(sortSpec).batchSize(1000).count(); }'
     },
     {
       name: 'should rewrite an IIFE to await and accept a generator',
@@ -125,13 +176,13 @@ describe('Repl Rewrite Tests', function() {
     },
     {
       name: 'should wrap awaited methods beginning with `!`',
-      input: 'assert(!cursor.hasNext());',
-      expected: 'assert(!(await cursor.hasNext()));'
+      input: 'assert(!db.test.find({}).hasNext());',
+      expected: 'assert(!(await db.test.find({}).hasNext()));'
     },
     {
       name: 'should not add additional awaits to a term thats already been awaited',
-      input: 'const results = find(options.query).toArray();',
-      expected: 'const results = await find(options.query).toArray();'
+      input: 'const results = db.test.find(options.query).toArray();',
+      expected: 'const results = await db.test.find(options.query).toArray();'
     },
     {
       name: 'should await future references to converted async method',
@@ -145,18 +196,18 @@ describe('Repl Rewrite Tests', function() {
     },
     {
       name: 'should wrap again better description',
-      input: 'assert.eq(1, t.find({$where: "return this.a == 2"}).toArray().length, "B");',
-      expected: 'assert.eq(1, (await t.find({$where: "return this.a == 2"}).toArray()).length, "B");'
+      input: 'assert.eq(1, db.test.find({$where: "return this.a == 2"}).toArray().length, "B");',
+      expected: 'assert.eq(1, (await db.test.find({$where: "return this.a == 2"}).toArray()).length, "B");'
     },
     {
       name: 'should properly wrap async methods when used with an `in` operator',
-      input: "assert(!('zeroPad' in col.findOne({_id: result.insertedId})));",
-      expected: "assert(!('zeroPad' in (await col.findOne({_id: result.insertedId}))));"
+      input: "assert(!('zeroPad' in db.test.findOne({_id: result.insertedId})));",
+      expected: "assert(!('zeroPad' in (await db.test.findOne({_id: result.insertedId}))));"
     },
     {
       name: 'should await async methods that are assigned to a variable',
-      input: 'doTest = function() { t.findOne({}); }; doTest();',
-      expected: 'doTest = async function() { await t.findOne({}); }; await doTest();'
+      input: 'doTest = function() { db.test.findOne({}); }; doTest();',
+      expected: 'doTest = async function() { await db.test.findOne({}); }; await doTest();'
     },
     {
       name: 'should wrap an async call with parens if subsequent calls on the object are not async',
@@ -164,9 +215,19 @@ describe('Repl Rewrite Tests', function() {
       expected: '(await db.getCollectionNames()).forEach(function(x) {});'
     },
     {
-      name: 'should not wrap explain with async decorations',
+      name: 'should not wrap explain with async decorations when called on collection',
       input: 'db.basic_test_1.explain().find({});',
       expected: 'db.basic_test_1.explain().find({});'
+    },
+    {
+      name: 'it should wrap explain with async decorations when called on cursor',
+      input: 'db.basic_test_1.find({}).skip(5).limit(10).explain();',
+      expected: 'await db.basic_test_1.find({}).skip(5).limit(10).explain();'
+    },
+    {
+      name: 'it should wrap explain with async decorations when called on cursor (2)',
+      input: 'var e = db.basic_test_1.find(query).hint({a: 1}).explain("executionStats");',
+      expected: 'var e = await db.basic_test_1.find(query).hint({a: 1}).explain("executionStats");'
     }
   ]);
 });


### PR DESCRIPTION
This makes the async translation a little bit smarter, by only
wrapping known async methods of expected types instead of
arbitrarily wrapping any method in a large array of methods that
we previously compiled.